### PR TITLE
2 bug fix and add WARNO

### DIFF
--- a/WargameModInstaller/AppBootstrapper.cs
+++ b/WargameModInstaller/AppBootstrapper.cs
@@ -75,6 +75,10 @@ namespace WargameModInstaller
             {
                 ConfigureForRD(kernel);
             }
+            else if (versionName == WargameVersionType.WARNO.Name)
+            {
+                ConfigureForWN(kernel);
+            }
         }
 
         protected virtual void ConfigureForALB(IKernel kernel)
@@ -94,6 +98,17 @@ namespace WargameModInstaller
             kernel.Bind<ICmdExecutorFactory>().To<CmdExecutorFactory>().InSingletonScope();
             kernel.Bind<IWargameInstallDirService>().To<RDInstallDirProvider>().InSingletonScope();
             kernel.Bind<IWargameProfileLocator>().To<RedDragonProfileLocator>().InSingletonScope();
+            kernel.Bind<IImageComposerService>().To<ImageComposerService>();
+            kernel.Bind<IContainerReaderService>().To<ContainerReaderService>().InSingletonScope();
+            kernel.Bind<IContainerWriterService>().To<ContainerWriterService>().InSingletonScope();
+        }
+
+        protected virtual void ConfigureForWN(IKernel kernel)
+        {
+            kernel.Bind<IInstallCmdReader>().To<InstallCmdReader>();
+            kernel.Bind<ICmdExecutorFactory>().To<CmdExecutorFactory>().InSingletonScope();
+            kernel.Bind<IWargameInstallDirService>().To<WNInstallDirProvider>().InSingletonScope();
+            kernel.Bind<IWargameProfileLocator>().To<WARNOProfileLocator>().InSingletonScope();
             kernel.Bind<IImageComposerService>().To<ImageComposerService>();
             kernel.Bind<IContainerReaderService>().To<ContainerReaderService>().InSingletonScope();
             kernel.Bind<IContainerWriterService>().To<ContainerWriterService>().InSingletonScope();

--- a/WargameModInstaller/Model/Config/WargameVersionType.cs
+++ b/WargameModInstaller/Model/Config/WargameVersionType.cs
@@ -12,6 +12,7 @@ namespace WargameModInstaller.Model.Config
         public static readonly WargameVersionType RedDragon = new WargameVersionType(1, "RD", "Wargame: Red Dragon");
         public static readonly WargameVersionType AirLandBattle = new WargameVersionType(2, "ALB", "Wargame: AirLand Battle");
         public static readonly WargameVersionType EuropeanEscalation = new WargameVersionType(3, "EE", "Wargame: European Escalation");
+        public static readonly WargameVersionType WARNO = new WargameVersionType(1, "WN", "WARNO");
 
         protected static HashSet<WargameVersionType> knownVersions;
 
@@ -21,6 +22,7 @@ namespace WargameModInstaller.Model.Config
             knownVersions.Add(RedDragon);
             knownVersions.Add(AirLandBattle);
             knownVersions.Add(EuropeanEscalation);
+            knownVersions.Add(WARNO);
         }
 
         public static bool IsKnownVersion(String versionName)

--- a/WargameModInstaller/Services/Install/WARNOProfileLocator.cs
+++ b/WargameModInstaller/Services/Install/WARNOProfileLocator.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WargameModInstaller.Services.Install.Base;
+
+namespace WargameModInstaller.Services.Install
+{
+    /// <summary>
+    /// A WARNO profile file locator.
+    /// </summary>
+    public class WARNOProfileLocator : WargameProfileLocatorBase
+    {
+        protected override string GetWargameSteamAppID()
+        {
+            return "1611600";
+        }
+
+    }
+}

--- a/WargameModInstaller/Services/Install/WNInstallDirProvider.cs
+++ b/WargameModInstaller/Services/Install/WNInstallDirProvider.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace WargameModInstaller.Services.Install
+{
+    public class WNInstallDirProvider : InstallDirProviderBase
+    {
+        protected override String GetWargameName()
+        {
+            return "WARNO.exe";
+        }
+
+        protected override String GetWargameFolderName()
+        {
+            return "WARNO";
+        }
+
+        protected override IEnumerable<String> GetPotentialInstallDirectoryPaths()
+        {
+            var programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            var programFilesName = (new DirectoryInfo(programFilesPath)).Name;
+
+            var results = new List<String>();
+            var drives = from d in DriveInfo.GetDrives()
+                         where d.DriveType == DriveType.Fixed
+                         select d.Name;
+            foreach (var drive in drives)
+            {
+                results.Add(Path.Combine(drive, programFilesName, @"Steam\SteamApps\common\WARNO\"));
+                results.Add(Path.Combine(drive, @"SteamLibrary\steamapps\common\WARNO\"));
+            }
+
+            return results;
+        }
+
+        protected override IEnumerable<String> GetPotentialInstallRegistryKeys()
+        {
+            var results = new List<String>();
+            results.Add(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 1611600");
+            results.Add(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 1611600");
+
+            return results;
+        }
+    }
+}

--- a/WargameModInstaller/ViewModels/InstallComponentScreenViewModel.cs
+++ b/WargameModInstaller/ViewModels/InstallComponentScreenViewModel.cs
@@ -189,15 +189,15 @@ namespace WargameModInstaller.ViewModels
                 {
                     var currentVM = vmQueue.Dequeue();
 
-                    foreach (var childVM in currentVM.Children)
-                    {
-                        vmQueue.Enqueue(childVM);
-                    }
-
                     var currentComponent = currentVM.WrappedComponent;
                     if (currentComponent.IsMarkedForInstall)
                     {
                         componentsToInstall.Add(currentComponent.Name);
+
+                        foreach (var childVM in currentVM.Children)
+                        {
+                            vmQueue.Enqueue(childVM);
+                        }
                     }
                 }
             }

--- a/WargameModInstaller/WargameModInstaller.csproj
+++ b/WargameModInstaller/WargameModInstaller.csproj
@@ -267,6 +267,8 @@
     <Compile Include="Services\Install\RDInstallDirProvider.cs" />
     <Compile Include="Services\Commands\SharedContainerCmdExecContext.cs" />
     <Compile Include="Services\Install\RedDragonProfileLocator.cs" />
+    <Compile Include="Services\Install\WARNOProfileLocator.cs" />
+    <Compile Include="Services\Install\WNInstallDirProvider.cs" />
     <Compile Include="Services\Utilities\DirectoryLocationService.cs" />
     <Compile Include="Services\Utilities\IDirectoryLocationService.cs" />
     <Compile Include="Services\Utilities\IMessageService.cs" />


### PR DESCRIPTION
* fix AlterDictionary -> AddEntry bug
> ToDo: update glyph entry.
Glyph entry should be latest.
Because entries below glyph are ignored.

* fix: bug that required component must be installed under exclusived parent.
> when parent is IsMarkedForInstall == false then child should be also false.

* add: service for WARNO
